### PR TITLE
fix for scoreboard nullref spam every frame for each player

### DIFF
--- a/GorillaCosmetics/CustomCosmeticsController.cs
+++ b/GorillaCosmetics/CustomCosmeticsController.cs
@@ -119,7 +119,8 @@ namespace GorillaCosmetics
 		void SetVRRigMaterial(Material material)
 		{
 			rig.materialsToChangeTo[MatIndex] = material;
-			if (rig.currentMatIndex == MatIndex)
+
+			if (rig.currentMatIndex == MatIndex || rig.currentMatIndex == 0)
 			{
 				rig.ChangeMaterialLocal(MatIndex);
 			}

--- a/GorillaCosmetics/CustomCosmeticsController.cs
+++ b/GorillaCosmetics/CustomCosmeticsController.cs
@@ -120,7 +120,7 @@ namespace GorillaCosmetics
 		{
 			rig.materialsToChangeTo[MatIndex] = material;
 
-			if (rig.currentMatIndex == MatIndex || rig.currentMatIndex == 0)
+			if (rig.currentMatIndex == 0)
 			{
 				rig.ChangeMaterialLocal(MatIndex);
 			}

--- a/GorillaCosmetics/CustomCosmeticsController.cs
+++ b/GorillaCosmetics/CustomCosmeticsController.cs
@@ -18,7 +18,6 @@ namespace GorillaCosmetics
 
 		GameObject currentHatObject;
 		Material defaultMaterial;
-		Material customMaterial;
 
 		VRRig rig;
 		string NickName => rig.photonView?.Owner?.NickName ?? "SELF";
@@ -26,6 +25,16 @@ namespace GorillaCosmetics
 		void Start()
 		{
 			rig = GetComponent<VRRig>();
+
+			var tempMatArray = rig.materialsToChangeTo;
+			rig.materialsToChangeTo = new Material[tempMatArray.Length + 1];
+
+			for (int index = 0; index < tempMatArray.Length; index++) {
+				rig.materialsToChangeTo[index] = tempMatArray[index];
+			}
+
+			rig.materialsToChangeTo[rig.materialsToChangeTo.Length - 1] = tempMatArray[0];
+
 			defaultMaterial = rig.mainSkin.material;
 			MatIndex = rig.materialsToChangeTo.Length - 1;
 

--- a/GorillaCosmetics/CustomCosmeticsController.cs
+++ b/GorillaCosmetics/CustomCosmeticsController.cs
@@ -123,7 +123,7 @@ namespace GorillaCosmetics
 
 			if (rig.currentMatIndex == 0)
 			{
-				rig.ChangeMaterialLocal(MatIndex);
+				rig.ChangeMaterialLocal(0);
 			}
 
 			rig.InitializeNoobMaterialLocal(defaultMaterial.color.r, defaultMaterial.color.g, defaultMaterial.color.b);

--- a/GorillaCosmetics/CustomCosmeticsController.cs
+++ b/GorillaCosmetics/CustomCosmeticsController.cs
@@ -18,6 +18,7 @@ namespace GorillaCosmetics
 
 		GameObject currentHatObject;
 		Material defaultMaterial;
+		Material customMaterial;
 
 		VRRig rig;
 		string NickName => rig.photonView?.Owner?.NickName ?? "SELF";
@@ -108,8 +109,8 @@ namespace GorillaCosmetics
 
 			if (CurrentMaterial != null) 
 			{
-				Material myMat = CurrentMaterial.GetMaterial();
-				if(myMat != null && myMat.HasProperty("_Color")) 
+				Material myMat = rig.materialsToChangeTo[MatIndex];
+				if(myMat != null && (CurrentMaterial.Descriptor.CustomColors || myMat.HasProperty("_Color"))) 
 				{
 					myMat.color = newColor;
 				}		

--- a/GorillaCosmetics/CustomCosmeticsController.cs
+++ b/GorillaCosmetics/CustomCosmeticsController.cs
@@ -10,6 +10,8 @@ namespace GorillaCosmetics
 {
 	public class CustomCosmeticsController : MonoBehaviour, ICustomCosmeticsController
 	{
+		public int MatIndex { get; private set; }
+
 		public GorillaHat CurrentHat { get; private set; }
 
 		public GorillaMaterial CurrentMaterial { get; private set; }
@@ -24,6 +26,7 @@ namespace GorillaCosmetics
 		{
 			rig = GetComponent<VRRig>();
 			defaultMaterial = rig.mainSkin.material;
+			MatIndex = rig.materialsToChangeTo.Length - 1;
 
 			Player player = rig.photonView?.Owner;
 			if (player != null)
@@ -96,18 +99,29 @@ namespace GorillaCosmetics
 			CurrentMaterial = null;
 		}
 
-		public void SetColor(float red, float blue, float green)
+		public void SetColor(float red, float green, float blue)
 		{
-			Plugin.Log($"Player: {NickName} changing color to {red}, {blue}, {green}");
-			defaultMaterial.color = new Color(red, blue, green);
+			Plugin.Log($"Player: {NickName} changing color to {red}, {green}, {blue}");
+
+			Color newColor = new Color(red, green, blue);
+			defaultMaterial.color = newColor;
+
+			if (CurrentMaterial != null) 
+			{
+				Material myMat = CurrentMaterial.GetMaterial();
+				if(myMat != null && myMat.HasProperty("_Color")) 
+				{
+					myMat.color = newColor;
+				}		
+			}
 		}
 
 		void SetVRRigMaterial(Material material)
 		{
-			rig.materialsToChangeTo[0] = material;
-			if (rig.currentMatIndex == 0)
+			rig.materialsToChangeTo[MatIndex] = material;
+			if (rig.currentMatIndex == MatIndex)
 			{
-				rig.ChangeMaterialLocal(0);
+				rig.ChangeMaterialLocal(MatIndex);
 			}
 
 			rig.InitializeNoobMaterialLocal(defaultMaterial.color.r, defaultMaterial.color.g, defaultMaterial.color.b);

--- a/GorillaCosmetics/CustomCosmeticsController.cs
+++ b/GorillaCosmetics/CustomCosmeticsController.cs
@@ -33,10 +33,9 @@ namespace GorillaCosmetics
 				rig.materialsToChangeTo[index] = tempMatArray[index];
 			}
 
-			rig.materialsToChangeTo[rig.materialsToChangeTo.Length - 1] = tempMatArray[0];
-
-			defaultMaterial = rig.mainSkin.material;
 			MatIndex = rig.materialsToChangeTo.Length - 1;
+			defaultMaterial = rig.materialsToChangeTo[0];
+			rig.materialsToChangeTo[MatIndex] = tempMatArray[0];
 
 			Player player = rig.photonView?.Owner;
 			if (player != null)

--- a/GorillaCosmetics/HarmonyPatches/Patches/ChangeMaterialPatch.cs
+++ b/GorillaCosmetics/HarmonyPatches/Patches/ChangeMaterialPatch.cs
@@ -1,0 +1,18 @@
+﻿using HarmonyLib;
+
+namespace GorillaCosmetics.HarmonyPatches.Patches
+{
+	[HarmonyPatch(typeof(VRRig))]
+	[HarmonyPatch("ChangeMaterialLocal", MethodType.Normal)]
+	internal class ChangeMaterialPatch
+	{
+		internal static void Prefix(VRRig __instance, ref int materialIndex)
+		{
+			var controller = __instance.gameObject.GetComponent<ICustomCosmeticsController>();
+			if (controller != null && materialIndex == 0) 
+			{
+				materialIndex = controller.MatIndex;
+			}
+		}
+	}
+}

--- a/GorillaCosmetics/HarmonyPatches/Patches/ChangeMaterialPatch.cs
+++ b/GorillaCosmetics/HarmonyPatches/Patches/ChangeMaterialPatch.cs
@@ -6,12 +6,24 @@ namespace GorillaCosmetics.HarmonyPatches.Patches
 	[HarmonyPatch("ChangeMaterialLocal", MethodType.Normal)]
 	internal class ChangeMaterialPatch
 	{
-		internal static void Prefix(VRRig __instance, ref int materialIndex)
+		internal static void Prefix(VRRig __instance, out bool __state, ref int materialIndex)
 		{
+			bool reset = false;
 			var controller = __instance.gameObject.GetComponent<ICustomCosmeticsController>();
 			if (controller != null && materialIndex == 0) 
 			{
+				reset = true;
 				materialIndex = controller.MatIndex;
+			}
+
+			__state = reset;
+		}
+
+		internal static void Postfix(VRRig __instance, in bool __state)
+		{
+			if(__state) 
+			{
+				__instance.setMatIndex = 0;
 			}
 		}
 	}

--- a/GorillaCosmetics/HarmonyPatches/Patches/ColorPatch.cs
+++ b/GorillaCosmetics/HarmonyPatches/Patches/ColorPatch.cs
@@ -11,12 +11,33 @@ namespace GorillaCosmetics.HarmonyPatches.Patches
 		internal static bool Prefix(VRRig __instance, float red, float green, float blue)
 		{
 			var controller = __instance.gameObject.GetComponent<ICustomCosmeticsController>();
+			if (controller == null) 
+			{
+				return true;
+			}
+
+			controller.SetColor(red, green, blue);
+
+			Photon.Pun.PhotonView photView = __instance.photonView;
+			if (photView != null) 
+			{
+				__instance.playerText.text = __instance.NormalizeName(true, photView.Owner.NickName);
+			} 
+			else if (__instance.showName)
+			{
+				__instance.playerText.text = PlayerPrefs.GetString("playerName");
+			}
+
+			return false;
+
+			/*
 			if (controller != null)
 			{
 				controller.SetColor(red, green, blue);
 			}
 			var boolean = controller?.CurrentMaterial?.Descriptor.CustomColors ?? true;
 			return boolean;
+			*/
 		}
 	}
 }

--- a/GorillaCosmetics/HarmonyPatches/Patches/ColorPatch.cs
+++ b/GorillaCosmetics/HarmonyPatches/Patches/ColorPatch.cs
@@ -40,5 +40,17 @@ namespace GorillaCosmetics.HarmonyPatches.Patches
 			*/
 		}
 	}
+
+	[HarmonyPatch(typeof(GorillaTagger))]
+	[HarmonyPatch("UpdateColor", MethodType.Normal)]
+	internal class UpdateColorPatch
+	{
+		internal static bool Prefix(GorillaTagger __instance, ref float red, ref float green, ref float blue)
+		{
+			__instance.offlineVRRig.InitializeNoobMaterialLocal(red, green, blue);
+			__instance.offlineVRRig.ChangeMaterialLocal(0);
+			return false;
+		}
+	}
 }
 

--- a/GorillaCosmetics/HarmonyPatches/Patches/CustomCosmeticsControllerCreationPatch.cs
+++ b/GorillaCosmetics/HarmonyPatches/Patches/CustomCosmeticsControllerCreationPatch.cs
@@ -15,6 +15,16 @@ namespace GorillaCosmetics.HarmonyPatches.Patches
 			Photon.Realtime.Player player = __instance.photonView?.Owner;
 
 			Plugin.Log($"GorillaCosmetics: Creating CustomCosmeticsController for {player?.NickName ?? "SELF"}");
+
+			var tempMatArray = __instance.materialsToChangeTo;
+			__instance.materialsToChangeTo = new Material[tempMatArray.Length + 1];
+
+			for (int index = 0; index < tempMatArray.Length; index++) {
+				__instance.materialsToChangeTo[index] = tempMatArray[index];
+			}
+
+			__instance.materialsToChangeTo[__instance.materialsToChangeTo.Length - 1] = tempMatArray[0];
+
 			__instance.gameObject.AddComponent<CustomCosmeticsController>();
 		}
 	}

--- a/GorillaCosmetics/HarmonyPatches/Patches/CustomCosmeticsControllerCreationPatch.cs
+++ b/GorillaCosmetics/HarmonyPatches/Patches/CustomCosmeticsControllerCreationPatch.cs
@@ -15,16 +15,6 @@ namespace GorillaCosmetics.HarmonyPatches.Patches
 			Photon.Realtime.Player player = __instance.photonView?.Owner;
 
 			Plugin.Log($"GorillaCosmetics: Creating CustomCosmeticsController for {player?.NickName ?? "SELF"}");
-
-			var tempMatArray = __instance.materialsToChangeTo;
-			__instance.materialsToChangeTo = new Material[tempMatArray.Length + 1];
-
-			for (int index = 0; index < tempMatArray.Length; index++) {
-				__instance.materialsToChangeTo[index] = tempMatArray[index];
-			}
-
-			__instance.materialsToChangeTo[__instance.materialsToChangeTo.Length - 1] = tempMatArray[0];
-
 			__instance.gameObject.AddComponent<CustomCosmeticsController>();
 		}
 	}

--- a/GorillaCosmetics/ICustomCosmeticsController.cs
+++ b/GorillaCosmetics/ICustomCosmeticsController.cs
@@ -7,6 +7,7 @@ namespace GorillaCosmetics
 {
 	public interface ICustomCosmeticsController
 	{
+		int MatIndex { get; }
 		GorillaHat CurrentHat { get; }
 		GorillaMaterial CurrentMaterial { get;  }
 
@@ -14,6 +15,6 @@ namespace GorillaCosmetics
 		void ResetHat();
 		void SetMaterial(GorillaMaterial material);
 		void ResetMaterial();
-		void SetColor(float red, float blue, float green);
+		void SetColor(float red, float green, float blue);
 	}
 }


### PR DESCRIPTION
every frame the scoreboard tries to set the player swatch color to the material color, if the custom material selected doesn't have a "_Color" property available it would cause the scoreboard line to throw a null error that's its missing, for each player its missing on. the same also happened when letting the scoreboard line use the material for the swatch material, it would throw an error over "_MainTex" being missing.

the solution i have is the expand the VRRig's array by 1 and add the custom material to the end, patch ChangeMaterialLocal so if the material wanted is the none infected material, set the index to be the end of the array where the custom material is saved, after the original function runs to update everything, set the VRRigs stored index value back to 0 so the scoreboard doesn't try to use the custom material for the swatch material.