### PR TITLE
fix for missing method definition error

### DIFF
--- a/GorillaCosmetics/CustomCosmeticsController.cs
+++ b/GorillaCosmetics/CustomCosmeticsController.cs
@@ -134,7 +134,7 @@ namespace GorillaCosmetics
 				rig.ChangeMaterialLocal(0);
 			}
 
-			rig.InitializeNoobMaterialLocal(defaultMaterial.color.r, defaultMaterial.color.g, defaultMaterial.color.b);
+			rig.InitializeNoobMaterialLocal(defaultMaterial.color.r, defaultMaterial.color.g, defaultMaterial.color.b, GorillaComputer.instance.leftHanded);
 		}
 	}
 }

--- a/GorillaCosmetics/HarmonyPatches/Patches/ColorPatch.cs
+++ b/GorillaCosmetics/HarmonyPatches/Patches/ColorPatch.cs
@@ -2,6 +2,8 @@ using System;
 using UnityEngine;
 using HarmonyLib;
 
+using GorillaNetworking;
+
 namespace GorillaCosmetics.HarmonyPatches.Patches
 {
 	[HarmonyPatch(typeof(VRRig))]
@@ -47,7 +49,7 @@ namespace GorillaCosmetics.HarmonyPatches.Patches
 	{
 		internal static bool Prefix(GorillaTagger __instance, ref float red, ref float green, ref float blue)
 		{
-			__instance.offlineVRRig.InitializeNoobMaterialLocal(red, green, blue);
+			__instance.offlineVRRig.InitializeNoobMaterialLocal(red, green, blue, GorillaComputer.instance.leftHanded);
 			__instance.offlineVRRig.ChangeMaterialLocal(0);
 			return false;
 		}


### PR DESCRIPTION
still needs a version number change, just a quick and dirty fix, might break in the future depending on how lemming handles the lefthanded stuff.